### PR TITLE
Use appropriate workflow url for workflow_dispatch event trigger

### DIFF
--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -7,13 +7,15 @@ export const commonContext = {
   sha: '2',
   owner: 'lazy-actions',
   repo: 'slatify',
-  number: 3
+  number: 3,
+  runId: 55
 };
 export const repoUrl = `https://github.com/${commonContext.owner}/${commonContext.repo}`;
 
 github.context.workflow = commonContext.workflow;
 github.context.ref = commonContext.ref;
 github.context.sha = commonContext.sha;
+github.context.runId = commonContext.runId;
 github.context.payload = {
   issue: {
     number: commonContext.number
@@ -43,6 +45,15 @@ describe('Workflow URL Tests', () => {
     const expectedUrls = {
       repo: repoUrl,
       action: `${repoUrl}/commit/${commonContext.sha}/checks`
+    };
+    expect(getWorkflowUrls()).toEqual(expectedUrls);
+  });
+
+  test('Workflow dispatch event', () => {
+    github.context.eventName = 'workflow_dispatch';
+    const expectedUrls = {
+      repo: repoUrl,
+      action: `${repoUrl}/actions/runs/${commonContext.runId}`
     };
     expect(getWorkflowUrls()).toEqual(expectedUrls);
   });

--- a/src/github.ts
+++ b/src/github.ts
@@ -46,6 +46,10 @@ function isPullRequest(): boolean {
   return context.eventName === 'pull_request';
 }
 
+function isWorkflowDispatch(): boolean {
+  return context.eventName === 'workflow_dispatch';
+}
+
 export function getWorkflowUrls(): WorkflowUrl {
   const {owner, repo} = context.repo;
   const repoUrl: string = `https://github.com/${owner}/${repo}`;
@@ -58,6 +62,9 @@ export function getWorkflowUrls(): WorkflowUrl {
     const number = context.issue.number;
     result.event = `${repoUrl}/pull/${number}`;
     result.action = `${result.event}/checks`;
+  } else if (isWorkflowDispatch()) {
+    const runId = context.runId;
+    result.action = `${repoUrl}/actions/runs/${runId}`
   } else {
     result.action = `${repoUrl}/commit/${context.sha}/checks`;
   }


### PR DESCRIPTION
without this change, for runs from the `workflow_dispatch` trigger, the url as is can point to a misleading run. it will always direct to the latest run on the branch in context, but obviously for anything that isn't the most recent run any more this will be incorrect.  so in this case, just use the run id instead.