### PR TITLE
Update index.js manually with recent changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - master

--- a/dist/index.js
+++ b/dist/index.js
@@ -14260,6 +14260,9 @@ exports.getCommit = getCommit;
 function isPullRequest() {
     return github_1.context.eventName === 'pull_request';
 }
+function isWorkflowDispatch() {
+    return github_1.context.eventName === 'workflow_dispatch';
+}
 function getWorkflowUrls() {
     const { owner, repo } = github_1.context.repo;
     const repoUrl = `https://github.com/${owner}/${repo}`;
@@ -14271,6 +14274,10 @@ function getWorkflowUrls() {
         const number = github_1.context.issue.number;
         result.event = `${repoUrl}/pull/${number}`;
         result.action = `${result.event}/checks`;
+    }
+    else if (isWorkflowDispatch()) {
+        const runId = github_1.context.runId;
+        result.action = `${repoUrl}/actions/runs/${runId}`;
     }
     else {
         result.action = `${repoUrl}/commit/${github_1.context.sha}/checks`;


### PR DESCRIPTION
It looks like we have the actions disabled (probably just the automatic disabling for forks), or something else is preventing them to be run, so when my last change was merged to master the js wasn't rebuilt. 

I've rebuilt it manually for now, but it might be good to try to enable the actions in future, at least the build one.