### PR TITLE
Add support to multiple webhook urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Please use moia-oss/slatify action.
 - [Inputs](#inputs)
 - [Examples](#examples)
   - [Basic usage](#basic-usage)
+  - [Multiple webhooks](#multiple-webhooks)
   - [Includes the latest commit information](#includes-the-latest-commit-information)
 - [Slack UI](#slack-ui)
 - [LICENSE](#license)
@@ -48,7 +49,8 @@ You can customize the following parameters:
 |:--:|:--:|:--|:--|
 |type|required|N/A|The result of GitHub Actions job<br>This parameter value must contain the following word:<br>- `success`<br>- `failure`<br>- `cancelled`<br>We recommend using ${{ job.status }}|
 |job_name|required|N/A|Means slack notification title|
-|url|required (or `slack_bot_token`)|N/A|Slack Incoming Webhooks URL<br>Please specify this key or SLACK_WEBHOOK environment variable<br>※SLACK_WEBHOOK will be deprecated|
+|url|required (or `urls` or `slack_bot_token`)|N/A|Slack Incoming Webhooks URL<br>Please specify this key or SLACK_WEBHOOK environment variable<br>※SLACK_WEBHOOK will be deprecated|
+|urls|required (or `url` or `slack_bot_token`)|N/A|Slack Incoming Webhooks URLs (newline-separated)<br>Takes precedence over `url`. Use this to send the same notification to multiple webhooks.|
 |slack_bot_token|required (or `url`)|N/A|Slack Bot Token<br>Please specify this key or SLACK_BOT_TOKEN environment variable
 |mention|optional|N/A|Slack message mention|
 |mention_if|optional|N/A|The condition to mention<br>This parameter can contain the following word:<br>- `success`<br>- `failure`<br>- `cancelled`<br>- `always`|
@@ -73,6 +75,20 @@ Please refer to [action.yml](./action.yml) for more details.
     job_name: '*Test*'
     channel: '#random'
     url: ${{ secrets.SLACK_WEBHOOK }}
+```
+
+### Multiple webhooks
+
+```..github/workflows/example3.yml
+- name: Slack Notification
+  uses: moia-oss/slatify@master
+  if: always()
+  with:
+    type: ${{ job.status }}
+    job_name: '*Deploy*'
+    urls: |
+      ${{ secrets.SLACK_WEBHOOK_TEAM_A }}
+      ${{ secrets.SLACK_WEBHOOK_TEAM_B }}
 ```
 
 ### Includes the latest commit information

--- a/__tests__/slack.test.ts
+++ b/__tests__/slack.test.ts
@@ -301,9 +301,7 @@ describe('Multiple Webhook Tests', () => {
 
     await expect(
       Slack.notifyMultipleWebhooks(urls, 'moia-oss', 'test', 'pray', payload)
-    ).rejects.toThrow(
-      'Failed to post message to 1 of 3 Slack webhook(s)'
-    );
+    ).rejects.toThrow('Failed to post message to 1 of 3 Slack webhook(s)');
   });
 
   test('All URLs fail', async () => {
@@ -314,9 +312,7 @@ describe('Multiple Webhook Tests', () => {
 
     await expect(
       Slack.notifyMultipleWebhooks(urls, 'moia-oss', 'test', 'pray', payload)
-    ).rejects.toThrow(
-      'Failed to post message to 2 of 2 Slack webhook(s)'
-    );
+    ).rejects.toThrow('Failed to post message to 2 of 2 Slack webhook(s)');
   });
 });
 

--- a/__tests__/slack.test.ts
+++ b/__tests__/slack.test.ts
@@ -246,6 +246,80 @@ describe('Webhook Payload Tests', () => {
   });
 });
 
+describe('Multiple Webhook Tests', () => {
+  const baseUrl = 'https://this.is.test';
+  const payload = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'payload.json'), {encoding: 'utf8'})
+  );
+
+  test('Post to multiple webhooks successfully', async () => {
+    nock(baseUrl).post('/webhook1').reply(200, 'ok');
+    nock(baseUrl).post('/webhook2').reply(200, 'ok');
+    nock(baseUrl).post('/webhook3').reply(200, 'ok');
+
+    const urls = [
+      `${baseUrl}/webhook1`,
+      `${baseUrl}/webhook2`,
+      `${baseUrl}/webhook3`
+    ];
+
+    const res = await Slack.notifyMultipleWebhooks(
+      urls,
+      'moia-oss',
+      'test',
+      'pray',
+      payload
+    );
+    expect(res).toBe(undefined);
+  });
+
+  test('Single URL works (backward compatibility)', async () => {
+    nock(baseUrl).post('/single').reply(200, 'ok');
+
+    const urls = [`${baseUrl}/single`];
+
+    const res = await Slack.notifyMultipleWebhooks(
+      urls,
+      'moia-oss',
+      'test',
+      'pray',
+      payload
+    );
+    expect(res).toBe(undefined);
+  });
+
+  test('Partial failure - attempts all URLs and reports errors', async () => {
+    nock(baseUrl).post('/success1').reply(200, 'ok');
+    nock(baseUrl).post('/failure1').reply(404, {error: 'channel_not_found'});
+    nock(baseUrl).post('/success2').reply(200, 'ok');
+
+    const urls = [
+      `${baseUrl}/success1`,
+      `${baseUrl}/failure1`,
+      `${baseUrl}/success2`
+    ];
+
+    await expect(
+      Slack.notifyMultipleWebhooks(urls, 'moia-oss', 'test', 'pray', payload)
+    ).rejects.toThrow(
+      'Failed to post message to 1 of 3 Slack webhook(s)'
+    );
+  });
+
+  test('All URLs fail', async () => {
+    nock(baseUrl).post('/fail1').reply(500, 'error');
+    nock(baseUrl).post('/fail2').reply(500, 'error');
+
+    const urls = [`${baseUrl}/fail1`, `${baseUrl}/fail2`];
+
+    await expect(
+      Slack.notifyMultipleWebhooks(urls, 'moia-oss', 'test', 'pray', payload)
+    ).rejects.toThrow(
+      'Failed to post message to 2 of 2 Slack webhook(s)'
+    );
+  });
+});
+
 describe('Post Message Tests', () => {
   const baseUrl = 'https://this.is.test';
   const payload = JSON.parse(

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,42 +1,4 @@
-import {parseUrls, validateStatus, isValidCondition} from '../src/utils';
-
-describe('parseUrls', () => {
-  test('Single URL', () => {
-    expect(parseUrls('https://hooks.slack.com/services/T00/B00/xxx')).toEqual([
-      'https://hooks.slack.com/services/T00/B00/xxx'
-    ]);
-  });
-
-  test('Newline-separated URLs', () => {
-    const input =
-      'https://hook1.example.com\nhttps://hook2.example.com\nhttps://hook3.example.com';
-    expect(parseUrls(input)).toEqual([
-      'https://hook1.example.com',
-      'https://hook2.example.com',
-      'https://hook3.example.com'
-    ]);
-  });
-
-  test('Commas in URLs are preserved', () => {
-    const input = 'https://hook1.example.com/path?a=1,2,3';
-    expect(parseUrls(input)).toEqual([
-      'https://hook1.example.com/path?a=1,2,3'
-    ]);
-  });
-
-  test('Handles whitespace and empty lines', () => {
-    const input =
-      '  https://hook1.example.com  \n\n  https://hook2.example.com  \n';
-    expect(parseUrls(input)).toEqual([
-      'https://hook1.example.com',
-      'https://hook2.example.com'
-    ]);
-  });
-
-  test('Empty string returns empty array', () => {
-    expect(parseUrls('')).toEqual([]);
-  });
-});
+import {validateStatus, isValidCondition} from '../src/utils';
 
 describe('validateStatus', () => {
   test('Valid statuses', () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -17,11 +17,10 @@ describe('parseUrls', () => {
     ]);
   });
 
-  test('Comma-separated URLs', () => {
-    const input = 'https://hook1.example.com,https://hook2.example.com';
+  test('Commas in URLs are preserved', () => {
+    const input = 'https://hook1.example.com/path?a=1,2,3';
     expect(parseUrls(input)).toEqual([
-      'https://hook1.example.com',
-      'https://hook2.example.com'
+      'https://hook1.example.com/path?a=1,2,3'
     ]);
   });
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,65 @@
+import {parseUrls, validateStatus, isValidCondition} from '../src/utils';
+
+describe('parseUrls', () => {
+  test('Single URL', () => {
+    expect(parseUrls('https://hooks.slack.com/services/T00/B00/xxx')).toEqual([
+      'https://hooks.slack.com/services/T00/B00/xxx'
+    ]);
+  });
+
+  test('Newline-separated URLs', () => {
+    const input =
+      'https://hook1.example.com\nhttps://hook2.example.com\nhttps://hook3.example.com';
+    expect(parseUrls(input)).toEqual([
+      'https://hook1.example.com',
+      'https://hook2.example.com',
+      'https://hook3.example.com'
+    ]);
+  });
+
+  test('Comma-separated URLs', () => {
+    const input = 'https://hook1.example.com,https://hook2.example.com';
+    expect(parseUrls(input)).toEqual([
+      'https://hook1.example.com',
+      'https://hook2.example.com'
+    ]);
+  });
+
+  test('Handles whitespace and empty lines', () => {
+    const input =
+      '  https://hook1.example.com  \n\n  https://hook2.example.com  \n';
+    expect(parseUrls(input)).toEqual([
+      'https://hook1.example.com',
+      'https://hook2.example.com'
+    ]);
+  });
+
+  test('Empty string returns empty array', () => {
+    expect(parseUrls('')).toEqual([]);
+  });
+});
+
+describe('validateStatus', () => {
+  test('Valid statuses', () => {
+    expect(validateStatus('success')).toBe('success');
+    expect(validateStatus('failure')).toBe('failure');
+    expect(validateStatus('cancelled')).toBe('cancelled');
+  });
+
+  test('Invalid status throws', () => {
+    expect(() => validateStatus('invalid')).toThrow('Invalid type parameter');
+  });
+});
+
+describe('isValidCondition', () => {
+  test('Valid conditions', () => {
+    expect(isValidCondition('always')).toBe(true);
+    expect(isValidCondition('success')).toBe(true);
+    expect(isValidCondition('failure')).toBe(true);
+    expect(isValidCondition('cancelled')).toBe(true);
+  });
+
+  test('Invalid condition', () => {
+    expect(isValidCondition('invalid')).toBe(false);
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   url:
     description: 'slack incoming webhook url'
     required: false
+  urls:
+    description: 'slack incoming webhook urls (newline-separated). Takes precedence over "url".'
+    required: false
   commit:
     description: 'whether include commit data or not (true or false)'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -40298,6 +40298,8 @@ function run() {
         const status = (0, utils_1.validateStatus)(core.getInput('type', { required: true }).toLowerCase());
         const jobName = core.getInput('job_name', { required: true });
         const url = process.env.SLACK_WEBHOOK || core.getInput('url');
+        const urlsInput = core.getInput('urls');
+        const urls = urlsInput ? (0, utils_1.parseUrls)(urlsInput) : [];
         const slackBotToken = process.env.SLACK_BOT_TOKEN || core.getInput('slack_bot_token');
         let mention = core.getInput('mention');
         let mentionCondition = core.getInput('mention_if').toLowerCase();
@@ -40313,10 +40315,10 @@ function run() {
       mention_if: ${mentionCondition} is invalid
       `);
         }
-        if (!url && !slackBotToken) {
+        if (!url && urls.length === 0 && !slackBotToken) {
             throw new Error(`Missing Slack Incoming Webhooks URL or Slack Bot Token.
       To use incoming webhooks please configure "SLACK_WEBHOOK" as an environment variable or
-      specify the "url" key.
+      specify the "url" or "urls" key.
 
       To use web api please configure "SLACK_BOT_TOKEN" as an environment variable or
       specify the "slack_bot_token" key.
@@ -40326,7 +40328,13 @@ function run() {
         if (commitFlag) {
             commit = yield github.getCommit(token);
         }
-        if (url) {
+        if (urls.length > 0) {
+            const payload = slack_1.Slack.generateWebhookPayload(jobName, status, mention, mentionCondition, commit);
+            core.debug(`Generated payload for slack webhooks: ${JSON.stringify(payload)}`);
+            yield slack_1.Slack.notifyMultipleWebhooks(urls, username, channel, icon_emoji, payload);
+            core.info(`Posted message to ${urls.length} Slack webhook(s)`);
+        }
+        else if (url) {
             const payload = slack_1.Slack.generateWebhookPayload(jobName, status, mention, mentionCondition, commit);
             core.debug(`Generated payload for slack webhook: ${JSON.stringify(payload)}`);
             yield slack_1.Slack.notifyWebhook(url, username, channel, icon_emoji, payload);
@@ -40539,6 +40547,19 @@ class Slack {
             }
         });
     }
+    static notifyMultipleWebhooks(urls, username, channel, icon_emoji, payload) {
+        return __awaiter(this, void 0, void 0, function* () {
+            var _a;
+            const results = yield Promise.allSettled(urls.map(url => Slack.notifyWebhook(url, username, channel, icon_emoji, payload)));
+            const failures = results.filter((r) => r.status === 'rejected');
+            if (failures.length > 0) {
+                for (const f of failures) {
+                    core.error(`Webhook delivery failed: ${((_a = f.reason) === null || _a === void 0 ? void 0 : _a.message) || String(f.reason)}`);
+                }
+                throw new Error(`Failed to post message to ${failures.length} of ${urls.length} Slack webhook(s)`);
+            }
+        });
+    }
     static notifyApi(token, payload) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
@@ -40570,6 +40591,7 @@ exports.Slack = Slack;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.validateStatus = validateStatus;
 exports.isValidCondition = isValidCondition;
+exports.parseUrls = parseUrls;
 const jobStatuses = ['success', 'failure', 'cancelled'];
 const metionConditions = [...jobStatuses, 'always'];
 function isValid(target, validList) {
@@ -40588,6 +40610,12 @@ function validateStatus(jobStatus) {
 }
 function isValidCondition(condition) {
     return isValid(condition, metionConditions);
+}
+function parseUrls(input) {
+    return input
+        .split(/[\n,]/)
+        .map(url => url.trim())
+        .filter(url => url.length > 0);
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -40298,8 +40298,6 @@ function run() {
         const status = (0, utils_1.validateStatus)(core.getInput('type', { required: true }).toLowerCase());
         const jobName = core.getInput('job_name', { required: true });
         const url = process.env.SLACK_WEBHOOK || core.getInput('url');
-        const urlsInput = core.getInput('urls');
-        const urls = urlsInput ? (0, utils_1.parseUrls)(urlsInput) : [];
         const slackBotToken = process.env.SLACK_BOT_TOKEN || core.getInput('slack_bot_token');
         let mention = core.getInput('mention');
         let mentionCondition = core.getInput('mention_if').toLowerCase();
@@ -40315,10 +40313,10 @@ function run() {
       mention_if: ${mentionCondition} is invalid
       `);
         }
-        if (!url && urls.length === 0 && !slackBotToken) {
+        if (!url && !slackBotToken) {
             throw new Error(`Missing Slack Incoming Webhooks URL or Slack Bot Token.
       To use incoming webhooks please configure "SLACK_WEBHOOK" as an environment variable or
-      specify the "url" or "urls" key.
+      specify the "url" key.
 
       To use web api please configure "SLACK_BOT_TOKEN" as an environment variable or
       specify the "slack_bot_token" key.
@@ -40328,13 +40326,7 @@ function run() {
         if (commitFlag) {
             commit = yield github.getCommit(token);
         }
-        if (urls.length > 0) {
-            const payload = slack_1.Slack.generateWebhookPayload(jobName, status, mention, mentionCondition, commit);
-            core.debug(`Generated payload for slack webhooks: ${JSON.stringify(payload)}`);
-            yield slack_1.Slack.notifyMultipleWebhooks(urls, username, channel, icon_emoji, payload);
-            core.info(`Posted message to ${urls.length} Slack webhook(s)`);
-        }
-        else if (url) {
+        if (url) {
             const payload = slack_1.Slack.generateWebhookPayload(jobName, status, mention, mentionCondition, commit);
             core.debug(`Generated payload for slack webhook: ${JSON.stringify(payload)}`);
             yield slack_1.Slack.notifyWebhook(url, username, channel, icon_emoji, payload);
@@ -40547,19 +40539,6 @@ class Slack {
             }
         });
     }
-    static notifyMultipleWebhooks(urls, username, channel, icon_emoji, payload) {
-        return __awaiter(this, void 0, void 0, function* () {
-            var _a;
-            const results = yield Promise.allSettled(urls.map(url => Slack.notifyWebhook(url, username, channel, icon_emoji, payload)));
-            const failures = results.filter((r) => r.status === 'rejected');
-            if (failures.length > 0) {
-                for (const f of failures) {
-                    core.error(`Webhook delivery failed: ${((_a = f.reason) === null || _a === void 0 ? void 0 : _a.message) || String(f.reason)}`);
-                }
-                throw new Error(`Failed to post message to ${failures.length} of ${urls.length} Slack webhook(s)`);
-            }
-        });
-    }
     static notifyApi(token, payload) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
@@ -40591,7 +40570,6 @@ exports.Slack = Slack;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.validateStatus = validateStatus;
 exports.isValidCondition = isValidCondition;
-exports.parseUrls = parseUrls;
 const jobStatuses = ['success', 'failure', 'cancelled'];
 const metionConditions = [...jobStatuses, 'always'];
 function isValid(target, validList) {
@@ -40610,12 +40588,6 @@ function validateStatus(jobStatus) {
 }
 function isValidCondition(condition) {
     return isValid(condition, metionConditions);
-}
-function parseUrls(input) {
-    return input
-        .split(/[\n,]/)
-        .map(url => url.trim())
-        .filter(url => url.length > 0);
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -40298,6 +40298,14 @@ function run() {
         const status = (0, utils_1.validateStatus)(core.getInput('type', { required: true }).toLowerCase());
         const jobName = core.getInput('job_name', { required: true });
         const url = process.env.SLACK_WEBHOOK || core.getInput('url');
+        const urlsInput = core.getInput('urls');
+        const webhookUrls = urlsInput ? (0, utils_1.parseUrls)(urlsInput) : [];
+        if (webhookUrls.length > 0 && url) {
+            core.warning('"urls" takes precedence over "url"');
+        }
+        else if (url) {
+            webhookUrls.push(url);
+        }
         const slackBotToken = process.env.SLACK_BOT_TOKEN || core.getInput('slack_bot_token');
         let mention = core.getInput('mention');
         let mentionCondition = core.getInput('mention_if').toLowerCase();
@@ -40313,10 +40321,10 @@ function run() {
       mention_if: ${mentionCondition} is invalid
       `);
         }
-        if (!url && !slackBotToken) {
+        if (webhookUrls.length === 0 && !slackBotToken) {
             throw new Error(`Missing Slack Incoming Webhooks URL or Slack Bot Token.
       To use incoming webhooks please configure "SLACK_WEBHOOK" as an environment variable or
-      specify the "url" key.
+      specify the "url" or "urls" key.
 
       To use web api please configure "SLACK_BOT_TOKEN" as an environment variable or
       specify the "slack_bot_token" key.
@@ -40326,11 +40334,11 @@ function run() {
         if (commitFlag) {
             commit = yield github.getCommit(token);
         }
-        if (url) {
+        if (webhookUrls.length > 0) {
             const payload = slack_1.Slack.generateWebhookPayload(jobName, status, mention, mentionCondition, commit);
-            core.debug(`Generated payload for slack webhook: ${JSON.stringify(payload)}`);
-            yield slack_1.Slack.notifyWebhook(url, username, channel, icon_emoji, payload);
-            core.info('Post message to Slack Webhook');
+            core.debug(`Generated payload for slack webhook(s): ${JSON.stringify(payload)}`);
+            yield slack_1.Slack.notifyMultipleWebhooks(webhookUrls, username, channel, icon_emoji, payload);
+            core.info(`Posted message to ${webhookUrls.length} Slack webhook(s)`);
         }
         else if (slackBotToken) {
             const payload = slack_1.Slack.generateApiPayload(username, channel, icon_emoji, jobName, status, mention, mentionCondition, commit);
@@ -40539,6 +40547,22 @@ class Slack {
             }
         });
     }
+    static notifyMultipleWebhooks(urls, username, channel, icon_emoji, payload) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const results = yield Promise.allSettled(urls.map(url => Slack.notifyWebhook(url, username, channel, icon_emoji, payload)));
+            const failures = [];
+            results.forEach((r, index) => {
+                var _a;
+                if (r.status === 'rejected') {
+                    failures.push({ index, reason: r.reason });
+                    core.error(`Webhook ${index + 1}/${urls.length} delivery failed: ${((_a = r.reason) === null || _a === void 0 ? void 0 : _a.message) || String(r.reason)}`);
+                }
+            });
+            if (failures.length > 0) {
+                throw new Error(`Failed to post message to ${failures.length} of ${urls.length} Slack webhook(s)`);
+            }
+        });
+    }
     static notifyApi(token, payload) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
@@ -40570,6 +40594,7 @@ exports.Slack = Slack;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.validateStatus = validateStatus;
 exports.isValidCondition = isValidCondition;
+exports.parseUrls = parseUrls;
 const jobStatuses = ['success', 'failure', 'cancelled'];
 const metionConditions = [...jobStatuses, 'always'];
 function isValid(target, validList) {
@@ -40588,6 +40613,12 @@ function validateStatus(jobStatus) {
 }
 function isValidCondition(condition) {
     return isValid(condition, metionConditions);
+}
+function parseUrls(input) {
+    return input
+        .split('\n')
+        .map(url => url.trim())
+        .filter(url => url.length > 0);
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -40298,8 +40298,7 @@ function run() {
         const status = (0, utils_1.validateStatus)(core.getInput('type', { required: true }).toLowerCase());
         const jobName = core.getInput('job_name', { required: true });
         const url = process.env.SLACK_WEBHOOK || core.getInput('url');
-        const urlsInput = core.getInput('urls');
-        const webhookUrls = urlsInput ? (0, utils_1.parseUrls)(urlsInput) : [];
+        const webhookUrls = core.getMultilineInput('urls');
         if (webhookUrls.length > 0 && url) {
             core.warning('"urls" takes precedence over "url"');
         }
@@ -40594,7 +40593,6 @@ exports.Slack = Slack;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.validateStatus = validateStatus;
 exports.isValidCondition = isValidCondition;
-exports.parseUrls = parseUrls;
 const jobStatuses = ['success', 'failure', 'cancelled'];
 const metionConditions = [...jobStatuses, 'always'];
 function isValid(target, validList) {
@@ -40613,12 +40611,6 @@ function validateStatus(jobStatus) {
 }
 function isValidCondition(condition) {
     return isValid(condition, metionConditions);
-}
-function parseUrls(input) {
-    return input
-        .split('\n')
-        .map(url => url.trim())
-        .filter(url => url.length > 0);
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import * as github from './github';
-import {validateStatus, isValidCondition} from './utils';
+import {validateStatus, isValidCondition, parseUrls} from './utils';
 import {Slack} from './slack';
 
 async function run() {
@@ -9,6 +9,8 @@ async function run() {
   );
   const jobName = core.getInput('job_name', {required: true});
   const url = process.env.SLACK_WEBHOOK || core.getInput('url');
+  const urlsInput = core.getInput('urls');
+  const urls = urlsInput ? parseUrls(urlsInput) : [];
   const slackBotToken =
     process.env.SLACK_BOT_TOKEN || core.getInput('slack_bot_token');
   let mention = core.getInput('mention');
@@ -27,10 +29,10 @@ async function run() {
       `);
   }
 
-  if (!url && !slackBotToken) {
+  if (!url && urls.length === 0 && !slackBotToken) {
     throw new Error(`Missing Slack Incoming Webhooks URL or Slack Bot Token.
       To use incoming webhooks please configure "SLACK_WEBHOOK" as an environment variable or
-      specify the "url" key.
+      specify the "url" or "urls" key.
 
       To use web api please configure "SLACK_BOT_TOKEN" as an environment variable or
       specify the "slack_bot_token" key.
@@ -42,7 +44,21 @@ async function run() {
     commit = await github.getCommit(token);
   }
 
-  if (url) {
+  if (urls.length > 0) {
+    const payload = Slack.generateWebhookPayload(
+      jobName,
+      status,
+      mention,
+      mentionCondition,
+      commit
+    );
+    core.debug(
+      `Generated payload for slack webhooks: ${JSON.stringify(payload)}`
+    );
+
+    await Slack.notifyMultipleWebhooks(urls, username, channel, icon_emoji, payload);
+    core.info(`Posted message to ${urls.length} Slack webhook(s)`);
+  } else if (url) {
     const payload = Slack.generateWebhookPayload(
       jobName,
       status,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core';
 import * as github from './github';
-import {validateStatus, isValidCondition, parseUrls} from './utils';
+import {validateStatus, isValidCondition} from './utils';
 import {Slack} from './slack';
 
 async function run() {
@@ -9,8 +9,7 @@ async function run() {
   );
   const jobName = core.getInput('job_name', {required: true});
   const url = process.env.SLACK_WEBHOOK || core.getInput('url');
-  const urlsInput = core.getInput('urls');
-  const webhookUrls = urlsInput ? parseUrls(urlsInput) : [];
+  const webhookUrls = core.getMultilineInput('urls');
   if (webhookUrls.length > 0 && url) {
     core.warning('"urls" takes precedence over "url"');
   } else if (url) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,12 @@ async function run() {
   const jobName = core.getInput('job_name', {required: true});
   const url = process.env.SLACK_WEBHOOK || core.getInput('url');
   const urlsInput = core.getInput('urls');
-  const urls = urlsInput ? parseUrls(urlsInput) : [];
+  const webhookUrls = urlsInput ? parseUrls(urlsInput) : [];
+  if (webhookUrls.length > 0 && url) {
+    core.warning('"urls" takes precedence over "url"');
+  } else if (url) {
+    webhookUrls.push(url);
+  }
   const slackBotToken =
     process.env.SLACK_BOT_TOKEN || core.getInput('slack_bot_token');
   let mention = core.getInput('mention');
@@ -29,7 +34,7 @@ async function run() {
       `);
   }
 
-  if (!url && urls.length === 0 && !slackBotToken) {
+  if (webhookUrls.length === 0 && !slackBotToken) {
     throw new Error(`Missing Slack Incoming Webhooks URL or Slack Bot Token.
       To use incoming webhooks please configure "SLACK_WEBHOOK" as an environment variable or
       specify the "url" or "urls" key.
@@ -44,7 +49,7 @@ async function run() {
     commit = await github.getCommit(token);
   }
 
-  if (urls.length > 0) {
+  if (webhookUrls.length > 0) {
     const payload = Slack.generateWebhookPayload(
       jobName,
       status,
@@ -52,26 +57,10 @@ async function run() {
       mentionCondition,
       commit
     );
-    core.debug(
-      `Generated payload for slack webhooks: ${JSON.stringify(payload)}`
-    );
+    core.debug(`Generated payload for slack webhook(s): ${JSON.stringify(payload)}`);
 
-    await Slack.notifyMultipleWebhooks(urls, username, channel, icon_emoji, payload);
-    core.info(`Posted message to ${urls.length} Slack webhook(s)`);
-  } else if (url) {
-    const payload = Slack.generateWebhookPayload(
-      jobName,
-      status,
-      mention,
-      mentionCondition,
-      commit
-    );
-    core.debug(
-      `Generated payload for slack webhook: ${JSON.stringify(payload)}`
-    );
-
-    await Slack.notifyWebhook(url, username, channel, icon_emoji, payload);
-    core.info('Post message to Slack Webhook');
+    await Slack.notifyMultipleWebhooks(webhookUrls, username, channel, icon_emoji, payload);
+    core.info(`Posted message to ${webhookUrls.length} Slack webhook(s)`);
   } else if (slackBotToken) {
     const payload = Slack.generateApiPayload(
       username,

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,9 +57,17 @@ async function run() {
       mentionCondition,
       commit
     );
-    core.debug(`Generated payload for slack webhook(s): ${JSON.stringify(payload)}`);
+    core.debug(
+      `Generated payload for slack webhook(s): ${JSON.stringify(payload)}`
+    );
 
-    await Slack.notifyMultipleWebhooks(webhookUrls, username, channel, icon_emoji, payload);
+    await Slack.notifyMultipleWebhooks(
+      webhookUrls,
+      username,
+      channel,
+      icon_emoji,
+      payload
+    );
     core.info(`Posted message to ${webhookUrls.length} Slack webhook(s)`);
   } else if (slackBotToken) {
     const payload = Slack.generateApiPayload(

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -175,6 +175,35 @@ export class Slack {
     }
   }
 
+  public static async notifyMultipleWebhooks(
+    urls: string[],
+    username: string,
+    channel: string,
+    icon_emoji: string,
+    payload: IncomingWebhookSendArguments
+  ): Promise<void> {
+    const results = await Promise.allSettled(
+      urls.map(url =>
+        Slack.notifyWebhook(url, username, channel, icon_emoji, payload)
+      )
+    );
+
+    const failures = results.filter(
+      (r): r is PromiseRejectedResult => r.status === 'rejected'
+    );
+
+    if (failures.length > 0) {
+      for (const f of failures) {
+        core.error(
+          `Webhook delivery failed: ${f.reason?.message || String(f.reason)}`
+        );
+      }
+      throw new Error(
+        `Failed to post message to ${failures.length} of ${urls.length} Slack webhook(s)`
+      );
+    }
+  }
+
   public static async notifyApi(
     token: string,
     payload: ChatPostMessageArguments

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -188,16 +188,17 @@ export class Slack {
       )
     );
 
-    const failures = results.filter(
-      (r): r is PromiseRejectedResult => r.status === 'rejected'
-    );
-
-    if (failures.length > 0) {
-      for (const f of failures) {
+    const failures: {index: number; reason: unknown}[] = [];
+    results.forEach((r, index) => {
+      if (r.status === 'rejected') {
+        failures.push({index, reason: r.reason});
         core.error(
-          `Webhook delivery failed: ${f.reason?.message || String(f.reason)}`
+          `Webhook ${index + 1}/${urls.length} delivery failed: ${r.reason?.message || String(r.reason)}`
         );
       }
+    });
+
+    if (failures.length > 0) {
       throw new Error(
         `Failed to post message to ${failures.length} of ${urls.length} Slack webhook(s)`
       );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,7 @@ export function isValidCondition(condition: string): boolean {
 
 export function parseUrls(input: string): string[] {
   return input
-    .split(/[\n,]/)
+    .split('\n')
     .map(url => url.trim())
     .filter(url => url.length > 0);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,10 +20,3 @@ export function validateStatus(jobStatus: string): string {
 export function isValidCondition(condition: string): boolean {
   return isValid(condition, metionConditions);
 }
-
-export function parseUrls(input: string): string[] {
-  return input
-    .split('\n')
-    .map(url => url.trim())
-    .filter(url => url.length > 0);
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,3 +20,10 @@ export function validateStatus(jobStatus: string): string {
 export function isValidCondition(condition: string): boolean {
   return isValid(condition, metionConditions);
 }
+
+export function parseUrls(input: string): string[] {
+  return input
+    .split(/[\n,]/)
+    .map(url => url.trim())
+    .filter(url => url.length > 0);
+}


### PR DESCRIPTION
Hey there 👋 

Our team would like to send deployment status notifications to both our organization's monitoring channel and our team-specific channel. Today, this requires duplicating the action step for each webhook URL, which adds unnecessary noise to our workflow files.

This PR adds a new `urls` input that accepts multiple webhook URLs (newline-separated), sending the same notification to all of them in parallel within a single step. The existing `url` input remains unchanged for backward compatibility.

```yaml
- name: Slack Notification
  uses: moia-oss/slatify@master
  if: always()
  with:
    type: ${{ job.status }}
    job_name: '*Deploy*'
    urls: |
      ${{ secrets.SLACK_WEBHOOK_ORG_MONITORING }}
      ${{ secrets.SLACK_WEBHOOK_TEAM_CHANNEL }}
```

Happy to adjust anything based on your feedback!